### PR TITLE
Fix catch block error variable

### DIFF
--- a/Create-WindowsInstallMedia.ps1
+++ b/Create-WindowsInstallMedia.ps1
@@ -461,7 +461,7 @@ If((Test-Path $WinPEDriverFolder) -and (Test-Path $ModelDriversFolder) -and (Tes
                             Dism /Split-Image /ImageFile:$WindowsSourceFolder\sources\install.wim /SWMFile:$WindowsSourceFolder\sources\install.swm /FileSize:$SplitSize > $null
                         }
                         catch {
-                            Write-host "Error encountered while splitting install.wim".Exception.Message -ForegroundColor Red
+                            Write-host "Error encountered while splitting install.wim"$_.Exception.Message -ForegroundColor Red
                         }
                         
                         Remove-Item -Path "$WindowsSourceFolder\sources\install.wim"


### PR DESCRIPTION
## Summary
- fix missing `$_` reference in install.wim split error handling
- add trailing newline to script

## Testing
- `pwsh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846b3755e288327baa3c6bae2ff563c